### PR TITLE
Rewriting to be Stateless

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ The page may take a while to load, as it waits for your Tesla to wake up.
 
 To use this endpoint, you need to generate a Tesla Access Token. You can do this using one of the following apps:
 
-- TODO: iOS App
-- TODO: Android App
+- iOS: Auth for Tesla
+- Android: Tesla Tokens
 
-One you have one of those tokens, you can pass it to the API endpoint using query params below.
+One you have one of the token, you can pass it to the API endpoint using query params below.
 
 ### Headers
 
@@ -52,10 +52,10 @@ To control the API endpoint, you can use the following headers
 
 | name                 | required? | description                                                |
 | -------------------- | --------- | ---------------------------------------------------------- |
-| X-TESLA_vin          | yes       | The VIN of the car you want to control                     |
-| X-TESLA_access_token | yes       | Your Tesla Access Token                                    |
-| X-TESLA_temp         | no        | Desired temperature in Celsius                             |
-| X-TESLA_seats        | no        | Comma-separated heat levels (0-3) for each seat. See below |
+| X-Tesla-vin          | yes       | The VIN of the car you want to control                     |
+| X-Tesla-access_token | yes       | Your Tesla Access Token                                    |
+| X-Tesla-temp         | no        | Desired temperature in Celsius                             |
+| X-Tesla-seats        | no        | Comma-separated heat levels (0-3) for each seat. See below |
 
 ### Seat Numbers
 
@@ -68,12 +68,17 @@ To control the API endpoint, you can use the following headers
 5 Rear right
 ```
 
-An example to turn on all seats to max: `X-TESLA_seats=3,3,3,0,3,3`
+An example to turn on all seats to max: `X-Tesla-seats=3,3,3,0,3,3`
 
 ## Setup iOS Shortcut
 
-- Install and Setup "AUth for Tesla" app.
+- Install and Setup "Auth for Tesla" app.
 - Open Shortcuts
 - Add a Shortcut
+- Add an action of "Get Access Token" provided by the Auth for Tesla app.
 - Add an action of "Get Contents Of URL"
-- Add your URL from above, including appending your token: `?access_token=YOUR_ACCESS_TOKEN` along with any other params you want.
+  - Add your URL from above
+  - Add the required + optional headers from above.
+  - For the X-Tesla-access_token header, you can tell it to use the "token" variable from the "Get Access Token" step above.
+- Optional: Add an action of "Get Dictionary From" and use the "Contents of URL" as the value
+- Optional: Add an action of "Show notification" and use the response from the dictonary step as the body

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ cp wrangler.toml.example wrangler.toml
 
 - Head over to [Cloudflare](https://dash.cloudflare.com/) and click on Workers
 - Add your `account_id` from Cloudflare Workers into `wrangler.toml`
-- On Cloudflare, click "KV", and add a namespace called `TESLA`
-- Copy that namespace ID into `wrangler.toml` into the `id` field under `kv_namespaces`
 - Publish to Cloudflare:
 
 ```bash
@@ -33,31 +31,33 @@ wrangler login # You only need to do this once
 wrangler publish
 ```
 
-- Make note of the URL it gives you at the end of this. You will need it later.
-
-Next, you need to configure your Tesla login details over in the Cloudflare Dashboard.
-
-- In Cloudflare Workers, click your worker (that was published in the step above)
-- Click "Settings"
-- Click "Edit Variables" under "Environment Variables"
-- Add `TESLA_EMAIL` and `TESLA_PASSWORD` and `VIN`
-- Add a random string to `TOKEN` - this will be used to protect your API endpoint from random people using it.
-
-This should now be setup. You can test that it's all working by going to the URL given previously, appended with `?token=YOUR_TOKEN`.
+> Make note of the URL it gives you at the end of this. You will need it later.
 
 By default, the script will wake up your Tesla and turn climate on. You can also specify the temperature (in Celsius) by adding a `temp` query argument and turn the seats on with `seats`.
 
 The page may take a while to load, as it waits for your Tesla to wake up.
 
-## Query params
+## Usage
 
-| name  | required? | description                                                      |
-| ----- | --------- | ---------------------------------------------------------------- |
-| token | yes       | The unique token you set in Cloudflare                           |
-| temp  | no        | Desired temperature in Celsius                                   |
-| seats | no        | Comma-separated heat levels (0-3) for each seat. See below       |
+To use this endpoint, you need to generate a Tesla Access Token. You can do this using one of the following apps:
 
-#### Seat Numbers
+- TODO: iOS App
+- TODO: Android App
+
+One you have one of those tokens, you can pass it to the API endpoint using query params below.
+
+### Query params
+
+To control the API endpoint, you can use the following query params
+
+| name         | required? | description                                                |
+| ------------ | --------- | ---------------------------------------------------------- |
+| vin          | yes       | The VIN of the car you want to control                     |
+| access_token | yes       | Your Tesla Access Token                                    |
+| temp         | no        | Desired temperature in Celsius                             |
+| seats        | no        | Comma-separated heat levels (0-3) for each seat. See below |
+
+### Seat Numbers
 
 ```
 0 Driver
@@ -75,18 +75,19 @@ An example to turn on all seats to max: `?seats=3,3,3,0,3,3`
 The bare minimum. Just turn on climate.
 
 ```
-https://tesla-precondition.your-subdomain.workers.dev?token=YOUR_TOKEN
+https://tesla.your-subdomain.workers.dev?access_token=YOUR_ACCESS_TOKEN
 ```
 
 Specify a temperature and turn on the two front seats (driver at level 3, passenger at level 1)
 
 ```
-https://tesla-precondition.your-subdomain.workers.dev?token=YOUR_TOKEN&temp=20&seats=3,1
+https://tesla.your-subdomain.workers.dev?access_token=YOUR_ACCESS_TOKEN&temp=20&seats=3,1
 ```
 
 ## Setup iOS Shortcut
 
+- Install and Setup "AUth for Tesla" app.
 - Open Shortcuts
 - Add a Shortcut
 - Add an action of "Get Contents Of URL"
-- Add your URL from above, including appending your token: `?token=YOUR_TOKEN`
+- Add your URL from above, including appending your token: `?access_token=YOUR_ACCESS_TOKEN` along with any other params you want.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ wrangler publish
 
 > Make note of the URL it gives you at the end of this. You will need it later.
 
-By default, the script will wake up your Tesla and turn climate on. You can also specify the temperature (in Celsius) by adding a `temp` query argument and turn the seats on with `seats`.
+By default, the script will wake up your Tesla and turn climate on. You can also specify the temperature (in Celsius) and turn on the seat heaters using headers (see below).
 
 The page may take a while to load, as it waits for your Tesla to wake up.
 
@@ -46,16 +46,16 @@ To use this endpoint, you need to generate a Tesla Access Token. You can do this
 
 One you have one of those tokens, you can pass it to the API endpoint using query params below.
 
-### Query params
+### Headers
 
-To control the API endpoint, you can use the following query params
+To control the API endpoint, you can use the following headers
 
-| name         | required? | description                                                |
-| ------------ | --------- | ---------------------------------------------------------- |
-| vin          | yes       | The VIN of the car you want to control                     |
-| access_token | yes       | Your Tesla Access Token                                    |
-| temp         | no        | Desired temperature in Celsius                             |
-| seats        | no        | Comma-separated heat levels (0-3) for each seat. See below |
+| name                 | required? | description                                                |
+| -------------------- | --------- | ---------------------------------------------------------- |
+| X-TESLA_vin          | yes       | The VIN of the car you want to control                     |
+| X-TESLA_access_token | yes       | Your Tesla Access Token                                    |
+| X-TESLA_temp         | no        | Desired temperature in Celsius                             |
+| X-TESLA_seats        | no        | Comma-separated heat levels (0-3) for each seat. See below |
 
 ### Seat Numbers
 
@@ -68,21 +68,7 @@ To control the API endpoint, you can use the following query params
 5 Rear right
 ```
 
-An example to turn on all seats to max: `?seats=3,3,3,0,3,3`
-
-## Examples
-
-The bare minimum. Just turn on climate.
-
-```
-https://tesla.your-subdomain.workers.dev?access_token=YOUR_ACCESS_TOKEN
-```
-
-Specify a temperature and turn on the two front seats (driver at level 3, passenger at level 1)
-
-```
-https://tesla.your-subdomain.workers.dev?access_token=YOUR_ACCESS_TOKEN&temp=20&seats=3,1
-```
+An example to turn on all seats to max: `X-TESLA_seats=3,3,3,0,3,3`
 
 ## Setup iOS Shortcut
 

--- a/README.md
+++ b/README.md
@@ -82,3 +82,6 @@ An example to turn on all seats to max: `X-Tesla-seats=3,3,3,0,3,3`
   - For the X-Tesla-access_token header, you can tell it to use the "token" variable from the "Get Access Token" step above.
 - Optional: Add an action of "Get Dictionary From" and use the "Contents of URL" as the value
 - Optional: Add an action of "Show notification" and use the response from the dictonary step as the body
+
+![image](https://user-images.githubusercontent.com/68361/140664905-83b004b0-2a08-4359-9220-2bed8b751e86.png)
+

--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ async function wakeVehicle(accessToken, vehicleID) {
   }
 }
 
-async function teslaRequest(accessToken, vehicleID, method, url, body = null, allowFailure = false) {
+async function teslaRequest(accessToken, vehicleID, method, url, body = null) {
   if (accessToken === null) {
     throw 'No access token provided'
   }
@@ -168,9 +168,9 @@ async function teslaRequest(accessToken, vehicleID, method, url, body = null, al
     throw 'Access Token invalid'
   }
 
-  if (allowFailure || response.status === 200) {
+  if (response.status === 200) {
     return response
   } else {
-    throw `Invalid response from ${fullUrl}: ` + (await response.text())
+    throw `Invalid response from ${fullUrl}: [${response.status}] ` + (await response.text())
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ addEventListener('fetch', event => {
  * @param {Request} request
  */
 async function handleRequest(request) {
-  const { searchParams } = new URL(request.url)
-  const accessToken = searchParams.get('access_token')
-  const vin = searchParams.get('vin')
-  const temperature = searchParams.get('temp')
-  const seats = searchParams.get('seats')
+  const accessToken = request.headers.get('X-TESLA_access_token')
+  const vin = request.headers.get('X-TESLA_vin')
+  const temperature = request.headers.get('X-TESLA_temp')
+  const seats = request.headers.get('X-TESLA_seats')
+
   let successMessage = 'Car is preconditioning'
 
   try {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function handleRequest(request) {
           await setSeatHeater(accessToken, vehicleID, seatNumber, seatLevel)
         }),
       )
-      successMessage += ', and the seats have been turned on'
+      successMessage += ', and the seats have been set.'
     }
 
     return jsonResponse(successMessage)

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ addEventListener('fetch', event => {
  * @param {Request} request
  */
 async function handleRequest(request) {
-  const accessToken = request.headers.get('X-TESLA_access_token')
-  const vin = request.headers.get('X-TESLA_vin')
-  const temperature = request.headers.get('X-TESLA_temp')
-  const seats = request.headers.get('X-TESLA_seats')
+  const accessToken = request.headers.get('X-Tesla-access_token')
+  const vin = request.headers.get('X-Tesla-vin')
+  const temperature = request.headers.get('X-Tesla-temp')
+  const seats = request.headers.get('X-Tesla-seats')
 
   let successMessage = 'Car is preconditioning'
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ async function jsonResponse(message) {
 }
 
 async function getVehicleIDFromVin(accessToken, vin) {
+  if (vin === null) {
+    throw 'No X-Tesla-vin header provided'
+  }
+
   console.log('Getting vehicle list')
 
   const vehiclesResponse = await teslaRequest(accessToken, null, 'GET', '/vehicles')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Scott Robertson <scottymeuk@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "prettier": "^1.18.2"
+    "prettier": "^2"
   },
   "dependencies": {}
 }

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -5,8 +5,6 @@ workers_dev = true
 route = ""
 zone_id = ""
 webpack_config = "webpack.config.js"
-kv_namespaces = [
-  { binding = "TESLA", id = "", preview_id = "" },
-]
+compatibility_date = "2021-11-07"
 
 vars = { CLIENT_ID = "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384", SECRET = "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-prettier@^1.18.2:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+"prettier@^1.18.2":
+  "integrity" "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+  "resolved" "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
+  "version" "1.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"prettier@^1.18.2":
-  "integrity" "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
-  "resolved" "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
-  "version" "1.19.1"
+prettier@^2:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
Now you need to pass an Access Token to every API call. This is super easy now due to the "Auth for Tesla" app exposing an "Get Access Token" action in Shortcuts app.

This also allows the removal of all env var configs.

Settings are now controlled via headers, as it's much nicer to use them in iOS/macOS shortcuts vs query params.

An example of how this can be used in iOS/macOS Shortcuts

![2021-11-07 at 22 44 59](https://user-images.githubusercontent.com/68361/140664600-b64cca10-c25a-43b8-8a84-5dc66bdd1a41.png)
